### PR TITLE
Use the system's region settings to define the time format.

### DIFF
--- a/src/StatusBarWindow.cs
+++ b/src/StatusBarWindow.cs
@@ -2,6 +2,7 @@
 using MobileShell.Controls;
 using MobileShell.Enums;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -197,7 +198,7 @@ namespace MobileShell
             //CLOCK
             DispatcherTimer dispClock = new DispatcherTimer(TimeSpan.FromMilliseconds(1000), DispatcherPriority.Render, delegate
             {
-                clockTextBox.Text = DateTime.Now.ToString("HH:mm"); //+- 1s
+                clockTextBox.Text = DateTime.Now.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimeFormat, CultureInfo.CurrentCulture.Name); //+- 1s
             }, Dispatcher);
 
             //TODO: better way

--- a/src/StatusBarWindow.cs
+++ b/src/StatusBarWindow.cs
@@ -198,7 +198,7 @@ namespace MobileShell
             //CLOCK
             DispatcherTimer dispClock = new DispatcherTimer(TimeSpan.FromMilliseconds(1000), DispatcherPriority.Render, delegate
             {
-                clockTextBox.Text = DateTime.Now.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimeFormat, CultureInfo.CurrentCulture.Name); //+- 1s
+                clockTextBox.Text = DateTime.Now.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimeFormat, CultureInfo.CreateSpecificCulture(CultureInfo.CurrentCulture.Name)); //+- 1s
             }, Dispatcher);
 
             //TODO: better way


### PR DESCRIPTION
These commits change the way the time is formatted to match with that of the user's installed region settings. For users in the US, this would render as the usual 12-hour clock, complete with AM/PM indicators.

This has been tested on my own devices and performs swimmingly.